### PR TITLE
Use latest stable apline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 ENV PHP_VERSION nightly
 ENV PHP_INI_DIR /usr/local/etc/php
@@ -24,7 +24,7 @@ RUN set -xe \
 		curl-dev \
 		libedit-dev \
 		libxml2-dev \
-		openssl-dev \
+		libressl-dev \
 		sqlite-dev \
 		bison \
         libbz2 \


### PR DESCRIPTION
Im sorry I made a mistake in my last PR. I must have been too quick when looking at the [Docker alpine](https://hub.docker.com/_/alpine) page. 

The latest version is 3.8 and not 3.6. 

Im working with the latest features of cUrl in PHP and that is why I would like to have a good docker image as base. 

See this short thread about the reasoning behind this PR: https://github.com/php/php-src/pull/3744#issuecomment-455909914