### PR TITLE
Add GitHub action and fix Docker image build test

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,0 +1,18 @@
+name: Docker image CI build
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  cd:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build Docker image
+        run: docker build -t docker-alpine-php-nightly .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 ENV PHP_VERSION nightly
 ENV PHP_INI_DIR /usr/local/etc/php
@@ -6,14 +6,14 @@ ENV PHP_INI_DIR /usr/local/etc/php
 RUN set -xe \
     && apk add --no-cache --virtual .persistent-deps \
         ca-certificates \
-		curl \
-		tar \
-		xz \
-		git
+        curl \
+        tar \
+        xz \
+        git
 
 RUN set -xe \
     && apk add --no-cache --virtual .build-deps \
-		autoconf \
+        autoconf \
         file \
         g++ \
         gcc \
@@ -21,15 +21,16 @@ RUN set -xe \
         make \
         pkgconf \
         re2c \
-		curl-dev \
-		libedit-dev \
-		libxml2-dev \
-		libressl-dev \
-		sqlite-dev \
-		bison \
+        curl-dev \
+        libedit-dev \
+        libxml2-dev \
+        openssl-dev \
+        oniguruma-dev \
+        sqlite-dev \
+        bison \
         libbz2 \
         bzip2-dev \
-	&& mkdir -p $PHP_INI_DIR/conf.d \
+    && mkdir -p $PHP_INI_DIR/conf.d \
     && git clone https://github.com/php/php-src.git /usr/src/php \
     && cd /usr/src/php \
     && ./buildconf \
@@ -50,13 +51,13 @@ RUN set -xe \
     && make install \
     && rm -rf /usr/src/php \
     && runDeps="$( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
-			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
-	    )" \
-	&& apk add --no-cache --virtual .php-rundeps $runDeps \
-	&& apk del .build-deps
+        scanelf --needed --nobanner --recursive /usr/local \
+            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+            | sort -u \
+            | xargs -r apk info --installed \
+            | sort -u \
+        )" \
+    && apk add --no-cache --virtual .php-rundeps $runDeps \
+    && apk del .build-deps
 
 CMD ["php", "-a"]


### PR DESCRIPTION
# Changed log
- Add GitHub action to test for Docker image building automatically.
- The `openssl` `1.1` version has released and support `TLS` `1.3` version.
It should install package `openssl-dev`.
However, the `libressl` package does not support `TLS` `1.3` version.
And using the `openssl-dev` package instead.
- The `Alpine` `3.8` only supports `openssl-dev` version is `1.0` and it should use `Alpine 3.9+` version to support `TLS` `1.3` version.
Otherwise it will throw following error message when `PHP-Nightly` compliation:
```
/usr/src/php/ext/openssl/xp_ssl.c: In function 'php_openssl_map_proto_version':
/usr/src/php/ext/openssl/xp_ssl.c:1054:11: error: 'TLS1_3_VERSION' undeclared (first use in this function)
```

- Add `oniguruma-dev ` package because the `PHP-Nightly` building is necessary.
Otherwise, it will throw `` error message when PHP building configuring.
```
......
checking for oniguruma... no
configure: error: Package requirements (oniguruma) were not met:

Package 'oniguruma', required by 'virtual:world', not found
......
```
- To be consistency, replace tab with 4 white spaces on `Dockerfile` file.

# References
Here are some references about `Dockerfile` changing reason.

- The Alpine `3.8` only includes [`openssl-dev` `1.0` version](https://pkgs.alpinelinux.org/packages?name=openssl-dev&branch=v3.8).
- The Alpine `3.9` includes [`openssl-dev` `1.0` version](https://pkgs.alpinelinux.org/packages?name=openssl-dev&branch=v3.9).
- `libressl` has not included [`TLS` `1.3` version support yet](https://github.com/libressl-portable/portable/issues/228).
- `OpenSSL` `1.1` version has been released and[ `TLS` `1.3` version supported](https://community.centminmod.com/threads/openssl-1-1-1-released-with-tls-1-3-support.15592/).
